### PR TITLE
Support Redmine 2.4.2

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -21,7 +21,7 @@ Redmine::Plugin.register :redmine_stealth do
   extend Redmine::I18n
 
   plugin_locale_glob = respond_to?(:directory) ?
-    File.join(directory, 'config', 'locales', '*.yml') :
+    File.join( File.dirname(__FILE__) , 'config', 'locales', '*.yml') :
     File.join(Rails.root, 'vendor', 'plugins',
               'redmine_stealth', 'config', 'locales', '*.yml')
 


### PR DESCRIPTION
Migrating to Redmine 2.4.2 make the plugin crash on update:

```
rake aborted!
no implicit conversion of nil into String
/home/redmine-2.4.2/plugins/redmine_stealth/init.rb:24:in `join'
/home/redmine-2.4.2/plugins/redmine_stealth/init.rb:24:in `block in <top (required)>'
/home/redmine-2.4.2/lib/redmine/plugin.rb:73:in `instance_eval'
/home/redmine-2.4.2/lib/redmine/plugin.rb:73:in `register'
/home/redmine-2.4.2/plugins/redmine_stealth/init.rb:19:in `<top (required)>'
/home/redmine-2.4.2/lib/redmine/plugin.rb:133:in `block in load'
/home/redmine-2.4.2/lib/redmine/plugin.rb:124:in `each'
/home/redmine-2.4.2/lib/redmine/plugin.rb:124:in `load'
/home/redmine-2.4.2/config/initializers/30-redmine.rb:19:in `<top (required)>'
/home/redmine-2.4.2/config/environment.rb:14:in `<top (required)>'
Tasks: TOP => redmine:plugins:migrate => environment
(See full trace by running task with --trace)
```

I have changed the directory variable with the current path of the file.
